### PR TITLE
Update Dockerfile to print the entrypoint log early

### DIFF
--- a/theory_docker/Dockerfile
+++ b/theory_docker/Dockerfile
@@ -13,4 +13,4 @@ RUN useradd -m boinc
 EXPOSE 80
 
 WORKDIR /boinc_slot_dir
-CMD ./entrypoint.sh
+CMD ./entrypoint.sh |tee /boinc_slot_dir/entrypoint.log


### PR DESCRIPTION
Minor change.
Creates `entrypoint.log` in the slot folder where it can be monitored by the user.