### PR TITLE
Disable 'dnf-makecache.timer'

### DIFF
--- a/Theory/vbox/user_data
+++ b/Theory/vbox/user_data
@@ -44,6 +44,8 @@ runcmd:
   # Setup CVMFS
   - dnf install -y cvmfs bind-utils netcat
   - cvmfs_config setup
+  # Disable unwanted systemd timer
+  - rm -f /etc/systemd/system/timers.target.wants/dnf-makecache.timer
   # Deploy App
   - echo "* * * * * root touch /shared/heartbeat " > /etc/cron.d/heartbeat-agent
   - wget https://github.com/lfield/lhcathome/archive/refs/heads/main.zip


### PR DESCRIPTION
`dnf-makecache.timer` periodically calls `dnf-makecache.service` which creates lots of internet requests to Linux repositories.
Since the downloaded packets are never used the timer should be disabled.

Hint:
The timer seems to be activated in the Alma base image.
Hence, all Alma images created on top of that base image should be revised.
Some may require the timer, others not.